### PR TITLE
Fix bug

### DIFF
--- a/src/main/java/seedu/bankwithus/parser/Parser.java
+++ b/src/main/java/seedu/bankwithus/parser/Parser.java
@@ -220,10 +220,15 @@ public class Parser {
      * @throws CorruptedSaveFileException if any of the parameters are corrupted
      */
     public void parseSavedFile(Scanner scanner) throws CorruptedSaveFileException, SaveFileIsEmptyException {
+        boolean hasAccounts = false;
         while (scanner.hasNextLine()) {
             String accountDetails = scanner.nextLine();
             if (accountDetails.isBlank()) {
-                throw new SaveFileIsEmptyException();
+                if (!hasAccounts) {
+                    throw new SaveFileIsEmptyException();
+                } else {
+                    throw new CorruptedSaveFileException();
+                }
             }
             String[] splitDetails = accountDetails.split(";");
             try {
@@ -252,6 +257,7 @@ public class Parser {
                     accountList.addAccount(name, balanceString, totalAmtWithdrawn, 
                             LocalDate.parse(lastWithdrawnDate), withdrawalLimit, amtToSave, untilWhen);
                 }
+                hasAccounts = true;
             } catch (Exception e) {
                 throw new CorruptedSaveFileException();
             }

--- a/src/main/java/seedu/bankwithus/parser/Parser.java
+++ b/src/main/java/seedu/bankwithus/parser/Parser.java
@@ -224,11 +224,7 @@ public class Parser {
         while (scanner.hasNextLine()) {
             String accountDetails = scanner.nextLine();
             if (accountDetails.isBlank()) {
-                if (!hasAccounts) {
-                    throw new SaveFileIsEmptyException();
-                } else {
-                    throw new CorruptedSaveFileException();
-                }
+                continue;
             }
             String[] splitDetails = accountDetails.split(";");
             try {
@@ -260,6 +256,9 @@ public class Parser {
                 hasAccounts = true;
             } catch (Exception e) {
                 throw new CorruptedSaveFileException();
+            }
+            if (!hasAccounts) {
+                throw new SaveFileIsEmptyException();
             }
         }
         scanner.close();


### PR DESCRIPTION
Adding blank line to the savefile causes the parser to think that there are no accounts, so new account was created. Modified such that blank lines in the savefile will be ignored, while still retaining the empty savefile exception trigger